### PR TITLE
Fix footer bg color when in light mode

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -1,6 +1,6 @@
 const Footer = () => {
 	return (
-		<footer className="fixed bottom-0 left-0 w-full bg-white border-t border-gray-200 shadow flex items-center p-2 bg-gray-800 border-gray-600">
+		<footer className="fixed bottom-0 left-0 w-full border-t border-gray-200 shadow flex items-center p-2 bg-gray-800 border-gray-600">
 			<div className="text-sm text-blue-200 mx-auto font-bold">
 				{new Date().getFullYear().toString()} | Team Steam
 			</div>


### PR DESCRIPTION
When in light mode, footer bg changes due to missed bg color duplicate