### PR TITLE
Improve responsive grid w/ text

### DIFF
--- a/client/src/components/FrontPage.jsx
+++ b/client/src/components/FrontPage.jsx
@@ -42,15 +42,15 @@ const FrontPage = () => {
 						return (
 							<div
 								key={game.id}
-								className="shadow-xl cursor-pointer"
+								className="shadow-xl cursor-pointer relative"
 								onClick={() => getGameDetails(game.id)}
 							>
 								<img
 									src={game.background_image}
 									alt="games"
-									className="h-48 w-full rounded-t"
+									className="lg:w-84 lg:h-48 md:h-56 w-full rounded"
 								/>
-								<p className="text-center text-white text-xl font-bold bg-blue-400/30 rounded-b border-b-4 border-blue-300/60">
+								<p className="absolute bottom-0 font-bold text-center bg-slate-800/80 text-slate-200 text-xl p-1 border-t border-slate-600 w-full rounded-b">
 									{game.name}
 								</p>
 							</div>

--- a/client/src/components/Library.jsx
+++ b/client/src/components/Library.jsx
@@ -19,29 +19,21 @@ const Library = () => {
 	}, []);
 	return (
 		<div className="w-5/6 mx-auto flex flex-col gap-2 rounded-b bg-gradient-to-r from-blue-200/40 to-blue-500/40 mb-10 p-2 mb-10">
-			<div className="flex justify-center">
-				<input
-					type="text"
-					name="search"
-					id="search"
-					placeholder="search"
-					className="p-1 w-1/3 rounded shadow"
-				/>
-				<img src={search} alt="search" className="invert w-8 h-8 p-1" />
-			</div>
 			<div
 				id="gallery"
-				className="w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2 pl-2"
+				className="w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2"
 			>
 				{library.length !== 0 ? (
 					library.map((game) => (
-						<div key={game.id} className="flex flex-col items-center relative">
+						<div key={game.id} className="flex flex-col items-center relative rounded">
 							<img
 								src={game.background_image}
 								alt="games"
-								className="min-w-full min-h-full rounded shadow-xl mb-2"
+								className="md:h-36 sm:w-80 sm:h-48 w-full rounded"
 							/>
-							<p className="text-slate-200 font-bold text-sm absolute bottom-0 bg-slate-800 rounded-b w-full text-center">{game.name}</p>
+							<p className="text-slate-200 font-bold text-sm absolute bottom-0 bg-slate-800/80 text-center p-1  border-t border-slate-600 w-full rounded-b">
+								{game.name}
+							</p>
 						</div>
 					))
 				) : (


### PR DESCRIPTION
I hate the images on this API to the point that I can't stop talking about it.

Debating if we should use a more natural image resizing for all breakpoints (w-full / h-full) with the different grid heights, or stick with the images slightly getting squeezed while getting closer to breakpoints. It is driving me crazy.

I also decided to remove the redundant search as I don't think our app will reach the robustness to utilize both search fields.